### PR TITLE
Replace degree-to-radian constant with variable

### DIFF
--- a/findtest.sh
+++ b/findtest.sh
@@ -48,12 +48,13 @@ haversine() {
     lat2=$3
     lon2=$4
 
+    deg_to_radian=0.017453292519943295
     dlat=$(echo "$lat2 - $lat1" | bc -l)
     dlon=$(echo "$lon2 - $lon1" | bc -l)
-    lat1=$(echo "$lat1 * 0.017453292519943295" | bc -l)
-    lat2=$(echo "$lat2 * 0.017453292519943295" | bc -l)
-    dlat=$(echo "$dlat * 0.017453292519943295" | bc -l)
-    dlon=$(echo "$dlon * 0.017453292519943295" | bc -l)
+    lat1=$(echo "$lat1 * $deg_to_radian" | bc -l)
+    lat2=$(echo "$lat2 * $deg_to_radian" | bc -l)
+    dlat=$(echo "$dlat * $deg_to_radian" | bc -l)
+    dlon=$(echo "$dlon * $deg_to_radian" | bc -l)
 
     a=$(echo "s($dlat/2)^2 + c($lat1) * c($lat2) * s($dlon/2)^2" | bc -l)
     c=$(echo "2 * a(sqrt($a) / sqrt(1 - $a))" | bc -l)


### PR DESCRIPTION
Add a variable for the degree to radian constant (pi/180) and replace that in the lat/long calculations.

Albeit minor, this reduces the number instances of the constant and aids in comprehension as we have a variable name to describe that constant now.

Tested and functioning. :grin:
Thank you for considering this PR!